### PR TITLE
Sanitize file names (fixes #1).

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -5,6 +5,7 @@ var mkdirp  = require('mkdirp');
 var _       = require('lodash');
 var async   = require('async');
 var path    = require('path');
+var sanitize = require("sanitize-filename");
 var config  = require('../config');
 var Imgur   = require('./imgur');
 
@@ -107,14 +108,15 @@ module.exports = {
   },
   download: function download(url, path, callback){
     var fileName = url.substr(url.lastIndexOf('/') + 1);
+    var sanitizedFileName = sanitize(fileName);
     
     mkdirp(path, function(err){
       if(err) throw err;
       
-      fs.exists(path + '/' + fileName, function(exists){
+      fs.exists(path + '/' + sanitizedFileName, function(exists){
         if(!exists){
-          request.get(url).pipe(fs.createWriteStream(path + '/' + fileName));
-          callback(null, path + '/' + fileName);      
+          request.get(url).pipe(fs.createWriteStream(path + '/' + sanitizedFileName));
+          callback(null, path + '/' + sanitizedFileName);      
         }else{
           callback("File Exists, Not Redownloaded");
         }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "lodash": "^3.5.0",
     "mkdirp": "^0.5.0",
     "request": "^2.53.0",
-    "winston": "^0.9.0"
+    "winston": "^0.9.0",
+    "sanitize-filename": "^1.3.0"
   }
 }


### PR DESCRIPTION
This branch adds _sanitize-filename_ (https://github.com/parshap/node-sanitize-filename) and sanitizes the file names before writing to disk.
