### PR TITLE
Support multiple subreddits

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,17 +1,10 @@
 module.exports = {
   storeByUser: false,
-  imgStore: 'data',
   concurrents: 10,
   domains: ['i.imgur.com', 'imgur.com'],
   reddit: {
     url: 'https://ssl.reddit.com',
     userAgent: 'scraperBot/0.1 by ndboost',
-    sub: 'wtf',
-    sortBy: 'new',
-    paging: false,
-    nsfw: true,
-    pages: 10, 
-    limit: 1000,
   },
   imgur: {
     urls: {
@@ -25,4 +18,24 @@ module.exports = {
     colorize: true,
     prettyPrint: true
   },
+  subreddits: [
+    {
+      name: 'pics',
+      imgStore: 'pics',
+      sortBy: 'new',
+      paging: false,
+      nsfw: true,
+      pages: 10, 
+      limit: 100
+    },
+    {
+      name: 'funny',
+      imgStore: 'funny',
+      sortBy: 'new',
+      paging: false,
+      nsfw: true,
+      pages: 10, 
+      limit: 100
+    }
+  ]
 }

--- a/lib/reddit.js
+++ b/lib/reddit.js
@@ -9,21 +9,21 @@ function Retrieve(url, callback){
 };
 
 module.exports = {
-  getData: function getPages(options, callback){
-    var url = options.url + '/r/' + options.sub + '.json?sort=' + options.sortBy + '&limit=' + options.limit;
+  getData: function(redditUrl, sub, callback){
+    var url = redditUrl + '/r/' + sub.name + '.json?sort=' + sub.sortBy + '&limit=' + sub.limit;
     console.log('Reddit URL is: ' + url);
     var pagesCount = 1;
     var pages = [];
     
     Retrieve(url, function(err, page){
       var currentPage = page;
-      console.log('Retrieved the first page of reddit posts in /r/' + options.sub);
+      console.log('Retrieved the first page of reddit posts in /r/' + sub.name);
       pages.push(currentPage);
       
-      if(options.paging){
-        console.log('Paging is enabled, grabbing a total of ' + options.pages + ' pages');
+      if(sub.paging){
+        console.log('Paging is enabled, grabbing a total of ' + sub.pages + ' pages');
         
-        while(pagesCount < options.pages){
+        while(pagesCount < sub.pages){
           url = url + '&after=' + currentPage.data.after;
           Retrieve(url, function(err, page){
             currentPage = page;

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -79,7 +79,7 @@ function scrape(sub, page, callback){
               // log.error(err);
               callback();   
             }else{
-              console.log('File Downloaded To: ', file);
+              console.log('File downloaded to: ', file);
               callback();    
             }
           });

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -10,84 +10,71 @@ var config  = require('../config');
 var Imgur   = require('./imgur');
 
 module.exports = {
-  scrape: function(page, callback){
-    var children = page.data.children;
-    async.filter(children, function(child, callback){
+  scrape: scrape,
+  download: download
+};
+
+function scrape(sub, page, callback){
+  var children = page.data.children;
+
+  var results = children.filter( function(child){
+    /**
+     * strip out nsfw posts if nsfw isn't enabled
+     **/
+    if(!sub.nsfw && child.data.over_18 === true){
+     // log.debug(child.data.url + ' is tagged as NSFW, removing');
+      return false;
+    }
       
-      /**
-       * strip out nsfw posts if nsfw isn't enabled
-       **/
-      if(!config.reddit.nsfw && child.data.over_18 === true){
-       // log.debug(child.data.url + ' is tagged as NSFW, removing');
-        callback(false);
+    /**
+     * strip out any non allowed domains
+     * imgur.com, i.imgur.com are the only two so far.
+     **/
+    if( !_.includes(config.domains, child.data.domain, 0) ){
+      return false;
+    }
+    return true
+  });
+    
+  async.eachLimit(results, config.concurrents, function(child, callback){
+    
+    var imgPath = path.join(sub.imgStore);
+    if(config.storeByUser){
+      imgPath = imgPath + '/' + child.data.author;  
+    }
+    
+    var hash = child.data.url.match(new RegExp("^https?:\/\/(www.)?imgur.com\/(?!gallery|a\/)([a-zA-Z0-9]+)"));
+    var album = child.data.url.match(new RegExp("^https?:\/\/(www.)?imgur.com\/a\/([a-zA-Z0-9]+)"));
+    
+    if( hash ){
+      Imgur.getData('hash', hash[2], config.imgur, function(err, image){
         
-      /**
-       * strip out any non allowed domains
-       * imgur.com, i.imgur.com are the only two so far.
-       **/
-      }else if( !_.includes(config.domains, child.data.domain, 0) ){
-        callback(false);
-      }else{
-        callback(true);
-      }
-      
-    },function(results){
-      
-      async.eachLimit(results, config.concurrents, function(child, callback){
+        var url = image.image.links.original;
+        module.exports.download(url, imgPath, function(err, file){
+          if(err){
+            // log.error(err);
+            callback();   
+          }else{
+            console.log('File Downloaded To: ', file);
+            callback();    
+          }
+        });
         
-        var imgPath = path.join(config.imgStore);
-        if(config.storeByUser){
-          imgPath = imgPath + '/' + child.data.author;  
+      });
+      
+    } else if( album ){
+      // log.debug('Getting images from album', album[2]);
+      Imgur.getData('album', album[2], config.imgur, function(err, images){
+        
+        var images = images.album.images;
+        var urls = [];
+        
+        for (var i = 0; i < images.length; i++) {
+          urls.push(images[i].links.original);
         }
         
-        var hash = child.data.url.match(new RegExp("^https?:\/\/(www.)?imgur.com\/(?!gallery|a\/)([a-zA-Z0-9]+)"));
-        var album = child.data.url.match(new RegExp("^https?:\/\/(www.)?imgur.com\/a\/([a-zA-Z0-9]+)"));
-        
-        if( hash ){
-          Imgur.getData('hash', hash[2], config.imgur, function(err, image){
-            
-            var url = image.image.links.original;
-            module.exports.download(url, imgPath, function(err, file){
-              if(err){
-                // log.error(err);
-                callback();   
-              }else{
-                console.log('File Downloaded To: ', file);
-                callback();    
-              }
-            });
-            
-          });
-          
-        }else if( album ){
-          // log.debug('Getting images from album', album[2]);
-          Imgur.getData('album', album[2], config.imgur, function(err, images){
-            
-            var images = images.album.images;
-            var urls = [];
-            
-            for (var i = 0; i < images.length; i++) {
-              urls.push(images[i].links.original);
-            }
-            
-            async.eachLimit(urls, config.concurrents, function(url, callback){
-              module.exports.download(url, imgPath, function(err, file){
-                if(err){
-                  // log.error(err);
-                  callback();   
-                }else{
-                  console.log('File Downloaded To: ', file);
-                  callback();    
-                }
-              });
-                
-            });
-            
-          });
-          
-        }else{
-          // log.debug('Getting image from url', child.data.url);
-          module.exports.download(child.data.url, imgPath, function(err, file){
+        async.eachLimit(urls, config.concurrents, function(url, callback){
+          module.exports.download(url, imgPath, function(err, file){
             if(err){
               // log.error(err);
               callback();   
@@ -96,33 +83,47 @@ module.exports = {
               callback();    
             }
           });
-          callback();
-        }
-      
-      callback(true);
-      
-      }, function(err){
+            
+        });
         
       });
-    });
-  },
-  download: function download(url, path, callback){
-    var fileName = url.substr(url.lastIndexOf('/') + 1);
-    var sanitizedFileName = sanitize(fileName);
-    
-    mkdirp(path, function(err){
-      if(err) throw err;
       
-      fs.exists(path + '/' + sanitizedFileName, function(exists){
-        if(!exists){
-          request.get(url).pipe(fs.createWriteStream(path + '/' + sanitizedFileName));
-          callback(null, path + '/' + sanitizedFileName);      
+    } else{
+      // log.debug('Getting image from url', child.data.url);
+      module.exports.download(child.data.url, imgPath, function(err, file){
+        if(err){
+          // log.error(err);
+          callback();   
         }else{
-          callback("File Exists, Not Redownloaded");
+          console.log('File downloaded to: ', file);
+          callback();    
         }
       });
-    });
-    
-  }
+      callback();
+    }
   
-};
+    callback(true);
+  
+  }, function(err){
+    console.log("Finished with " + sub.name);
+    callback();
+  });
+}
+
+function download(url, path, callback){
+  var fileName = url.substr(url.lastIndexOf('/') + 1);
+  var sanitizedFileName = sanitize(fileName);
+  
+  mkdirp(path, function(err){
+    if(err) throw err;
+    
+    fs.exists(path + '/' + sanitizedFileName, function(exists){
+      if(!exists){
+        request.get(url).pipe(fs.createWriteStream(path + '/' + sanitizedFileName));
+        callback(null, path + '/' + sanitizedFileName);      
+      }else{
+        callback("File exists, not re-downloaded");
+      }
+    });
+  });
+}

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -55,7 +55,7 @@ function scrape(sub, page, callback){
             // log.error(err);
             callback();   
           }else{
-            console.log('File Downloaded To: ', file);
+            console.log('File downloaded to: ', file);
             callback();    
           }
         });


### PR DESCRIPTION
The main effort here is a change to the config format in order to support multiple subreddits.  The subreddits are processed in series (sequentially and synchronously).  Each subreddit has independent settings for `imgStore`, `nsfw`, `sortBy`, `paging`, `pages`, and `limit`.  Concurrency setting, user agent, and storeByUser are still globally configured. 

I also pulled out some functions in the scraper to make the indent levels a bit more manageable.  I also de-asyn'd the filtering since there's no I/O involved, and it also reduced an indent level and makes it easier to follow.

Thanks for this cool project, it works out of the box as advertised!
